### PR TITLE
Feat/service interfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ _testmain.go
 *.prof
 
 # for this repo only
+/.idea/

--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,11 @@ go 1.12
 
 require (
 	github.com/blang/semver v0.0.0-20190414102917-ba2c2ddd8906
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/go-querystring v1.0.0
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/satori/go.uuid v1.2.0
 	github.com/stretchr/testify v1.4.0
+	github.com/vburenin/ifacemaker v1.0.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
+github.com/jessevdk/go-flags v1.4.1-0.20181029123624-5de817a9aa20 h1:dAOsPLhnBzIyxu0VvmnKjlNcIlgMK+erD6VRHDtweMI=
+github.com/jessevdk/go-flags v1.4.1-0.20181029123624-5de817a9aa20/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
@@ -17,8 +19,13 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/vburenin/ifacemaker v1.0.0 h1:IPCW+3n07ZQQxSwGnodqyqAGMku5Tmk6XaZ/bqy1nuY=
+github.com/vburenin/ifacemaker v1.0.0/go.mod h1:SlS6qpTccQsoK3ln7mBkUxA4agA8wfPr/IFYqBWerPw=
+golang.org/x/tools v0.0.0-20181201035826-d0ca3933b724 h1:eV9myT/I6o1p8salzgZ0f1pz54PEgUf2NkCxEf6t+xs=
+golang.org/x/tools v0.0.0-20181201035826-d0ca3933b724/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/hack/generate-ifacemaker-comments.sh
+++ b/hack/generate-ifacemaker-comments.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+extractStructName() {
+  local filename=$1
+  echo "$(grep -Eow "type (.*) service" "$filename" | cut -d' ' -f2)"
+}
+
+generateInterfaceFilename() {
+  local filename=$1
+  output=${filename//.go/}
+  echo "${output}_interface.go"
+}
+
+processFiles() {
+  local filenames=$1
+
+  for filename in $filenames
+  do
+    ## Get the necessary names
+    structName=$(extractStructName "$filename")
+    interfaceFilename=$(generateInterfaceFilename "$filename")
+
+    ## Create the 'go generate' comment
+    goGenerate="//go:generate ifacemaker -f $filename -s $structName -i ${structName}Interface -p kong -c \"DO NOT EDIT: Auto generated\" -o ${interfaceFilename}"
+
+    ## a blank line for readability
+    sed -i "2a\ " "$filename"
+
+    ## Inject the go:generate comment into the file
+    sed -i "3i${goGenerate}" "$filename"
+  done
+}
+
+main() {
+  pushd ../kong >> /dev/null || exit
+
+  local filenames
+  filenames=$(ls -b *service.go)
+
+  processFiles "$filenames"
+
+  popd >> /dev/null || exit
+}
+
+main

--- a/kong/acl_service.go
+++ b/kong/acl_service.go
@@ -1,5 +1,7 @@
 package kong
 
+//go:generate ifacemaker -f acl_service.go -s ACLService -i ACLServiceInterface -p kong -c "DO NOT EDIT: Auto generated" -o acl_service_interface.go
+ 
 import (
 	"context"
 	"encoding/json"

--- a/kong/acl_service_interface.go
+++ b/kong/acl_service_interface.go
@@ -1,0 +1,33 @@
+// DO NOT EDIT: Auto generated
+
+package kong
+
+import (
+	"context"
+)
+
+// ACLServiceInterface ...
+type ACLServiceInterface interface {
+	// Create adds a consumer to an ACL group in Kong
+	// If an ID is specified, it will be used to
+	// create the group association in Kong, otherwise an ID
+	// is auto-generated.
+	Create(ctx context.Context, consumerUsernameOrID *string, aclGroup *ACLGroup) (*ACLGroup, error)
+	// Get fetches an ACL group for a consumer in Kong.
+	Get(ctx context.Context, consumerUsernameOrID, groupOrID *string) (*ACLGroup, error)
+	// Update updates an ACL group for a consumer in Kong
+	Update(ctx context.Context, consumerUsernameOrID *string, aclGroup *ACLGroup) (*ACLGroup, error)
+	// Delete deletes an ACL group association for a consumer in Kong
+	Delete(ctx context.Context, consumerUsernameOrID, groupOrID *string) error
+	// List fetches a list of all ACL group and consumer associations in Kong.
+	// opt can be used to control pagination.
+	List(ctx context.Context, opt *ListOpt) ([]*ACLGroup, *ListOpt, error)
+	// ListAll fetches all all ACL group associations in Kong.
+	// This method can take a while if there
+	// a lot of ACLGroup associations are present.
+	ListAll(ctx context.Context) ([]*ACLGroup, error)
+	// ListForConsumer fetches a list of ACL groups
+	// in Kong associated with a specific consumer.
+	// opt can be used to control pagination.
+	ListForConsumer(ctx context.Context, consumerUsernameOrID *string, opt *ListOpt) ([]*ACLGroup, *ListOpt, error)
+}

--- a/kong/basic_auth_service.go
+++ b/kong/basic_auth_service.go
@@ -1,5 +1,7 @@
 package kong
 
+//go:generate ifacemaker -f basic_auth_service.go -s BasicAuthService -i BasicAuthServiceInterface -p kong -c "DO NOT EDIT: Auto generated" -o basic_auth_service_interface.go
+ 
 import (
 	"context"
 	"encoding/json"

--- a/kong/basic_auth_service_interface.go
+++ b/kong/basic_auth_service_interface.go
@@ -1,0 +1,33 @@
+// DO NOT EDIT: Auto generated
+
+package kong
+
+import (
+	"context"
+)
+
+// BasicAuthServiceInterface ...
+type BasicAuthServiceInterface interface {
+	// Create creates a basic-auth credential in Kong
+	// If an ID is specified, it will be used to
+	// create a basic-auth in Kong, otherwise an ID
+	// is auto-generated.
+	Create(ctx context.Context, consumerUsernameOrID *string, basicAuth *BasicAuth) (*BasicAuth, error)
+	// Get fetches a basic-auth credential from Kong.
+	Get(ctx context.Context, consumerUsernameOrID, usernameOrID *string) (*BasicAuth, error)
+	// Update updates a basic-auth credential in Kong
+	Update(ctx context.Context, consumerUsernameOrID *string, basicAuth *BasicAuth) (*BasicAuth, error)
+	// Delete deletes a basic-auth credential in Kong
+	Delete(ctx context.Context, consumerUsernameOrID, usernameOrID *string) error
+	// List fetches a list of basic-auth credentials in Kong.
+	// opt can be used to control pagination.
+	List(ctx context.Context, opt *ListOpt) ([]*BasicAuth, *ListOpt, error)
+	// ListAll fetches all basic-auth credentials in Kong.
+	// This method can take a while if there
+	// a lot of basic-auth credentials present.
+	ListAll(ctx context.Context) ([]*BasicAuth, error)
+	// ListForConsumer fetches a list of basic-auth credentials
+	// in Kong associated with a specific consumer.
+	// opt can be used to control pagination.
+	ListForConsumer(ctx context.Context, consumerUsernameOrID *string, opt *ListOpt) ([]*BasicAuth, *ListOpt, error)
+}

--- a/kong/ca_certificate_service.go
+++ b/kong/ca_certificate_service.go
@@ -1,5 +1,7 @@
 package kong
 
+//go:generate ifacemaker -f ca_certificate_service.go -s CACertificateService -i CACertificateServiceInterface -p kong -c "DO NOT EDIT: Auto generated" -o ca_certificate_service_interface.go
+ 
 import (
 	"context"
 	"encoding/json"

--- a/kong/ca_certificate_service_interface.go
+++ b/kong/ca_certificate_service_interface.go
@@ -1,0 +1,29 @@
+// DO NOT EDIT: Auto generated
+
+package kong
+
+import (
+	"context"
+)
+
+// CACertificateServiceInterface ...
+type CACertificateServiceInterface interface {
+	// Create creates a CACertificate in Kong.
+	// If an ID is specified, it will be used to
+	// create a certificate in Kong, otherwise an ID
+	// is auto-generated.
+	Create(ctx context.Context, certificate *CACertificate) (*CACertificate, error)
+	// Get fetches a CACertificate in Kong.
+	Get(ctx context.Context, ID *string) (*CACertificate, error)
+	// Update updates a CACertificate in Kong
+	Update(ctx context.Context, certificate *CACertificate) (*CACertificate, error)
+	// Delete deletes a CACertificate in Kong
+	Delete(ctx context.Context, ID *string) error
+	// List fetches a list of certificate in Kong.
+	// opt can be used to control pagination.
+	List(ctx context.Context, opt *ListOpt) ([]*CACertificate, *ListOpt, error)
+	// ListAll fetches all Certificates in Kong.
+	// This method can take a while if there
+	// a lot of Certificates present.
+	ListAll(ctx context.Context) ([]*CACertificate, error)
+}

--- a/kong/certificate_service.go
+++ b/kong/certificate_service.go
@@ -1,5 +1,7 @@
 package kong
 
+//go:generate ifacemaker -f certificate_service.go -s CertificateService -i CertificateServiceInterface -p kong -c "DO NOT EDIT: Auto generated" -o certificate_service_interface.go
+ 
 import (
 	"context"
 	"encoding/json"

--- a/kong/certificate_service_interface.go
+++ b/kong/certificate_service_interface.go
@@ -1,0 +1,29 @@
+// DO NOT EDIT: Auto generated
+
+package kong
+
+import (
+	"context"
+)
+
+// CertificateServiceInterface ...
+type CertificateServiceInterface interface {
+	// Create creates a Certificate in Kong.
+	// If an ID is specified, it will be used to
+	// create a certificate in Kong, otherwise an ID
+	// is auto-generated.
+	Create(ctx context.Context, certificate *Certificate) (*Certificate, error)
+	// Get fetches a Certificate in Kong.
+	Get(ctx context.Context, usernameOrID *string) (*Certificate, error)
+	// Update updates a Certificate in Kong
+	Update(ctx context.Context, certificate *Certificate) (*Certificate, error)
+	// Delete deletes a Certificate in Kong
+	Delete(ctx context.Context, usernameOrID *string) error
+	// List fetches a list of certificate in Kong.
+	// opt can be used to control pagination.
+	List(ctx context.Context, opt *ListOpt) ([]*Certificate, *ListOpt, error)
+	// ListAll fetches all Certificates in Kong.
+	// This method can take a while if there
+	// a lot of Certificates present.
+	ListAll(ctx context.Context) ([]*Certificate, error)
+}

--- a/kong/consumer_service.go
+++ b/kong/consumer_service.go
@@ -1,5 +1,7 @@
 package kong
 
+//go:generate ifacemaker -f consumer_service.go -s ConsumerService -i ConsumerServiceInterface -p kong -c "DO NOT EDIT: Auto generated" -o consumer_service_interface.go
+ 
 import (
 	"context"
 	"encoding/json"

--- a/kong/consumer_service_interface.go
+++ b/kong/consumer_service_interface.go
@@ -1,0 +1,31 @@
+// DO NOT EDIT: Auto generated
+
+package kong
+
+import (
+	"context"
+)
+
+// ConsumerServiceInterface ...
+type ConsumerServiceInterface interface {
+	// Create creates a Consumer in Kong.
+	// If an ID is specified, it will be used to
+	// create a consumer in Kong, otherwise an ID
+	// is auto-generated.
+	Create(ctx context.Context, consumer *Consumer) (*Consumer, error)
+	// Get fetches a Consumer in Kong.
+	Get(ctx context.Context, usernameOrID *string) (*Consumer, error)
+	// GetByCustomID fetches a Consumer in Kong.
+	GetByCustomID(ctx context.Context, customID *string) (*Consumer, error)
+	// Update updates a Consumer in Kong
+	Update(ctx context.Context, consumer *Consumer) (*Consumer, error)
+	// Delete deletes a Consumer in Kong
+	Delete(ctx context.Context, usernameOrID *string) error
+	// List fetches a list of Consumers in Kong.
+	// opt can be used to control pagination.
+	List(ctx context.Context, opt *ListOpt) ([]*Consumer, *ListOpt, error)
+	// ListAll fetches all Consumers in Kong.
+	// This method can take a while if there
+	// a lot of Consumers present.
+	ListAll(ctx context.Context) ([]*Consumer, error)
+}

--- a/kong/credentials_service.go
+++ b/kong/credentials_service.go
@@ -1,5 +1,7 @@
 package kong
 
+//go:generate ifacemaker -f credentials_service.go -s credentialService -i credentialServiceInterface -p kong -c "DO NOT EDIT: Auto generated" -o credentials_service_interface.go
+ 
 import (
 	"context"
 	"encoding/json"

--- a/kong/credentials_service_interface.go
+++ b/kong/credentials_service_interface.go
@@ -1,0 +1,23 @@
+// DO NOT EDIT: Auto generated
+
+package kong
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// credentialServiceInterface ...
+type credentialServiceInterface interface {
+	// Create creates a credential in Kong of type credType.
+	// If an ID is specified in the credential, it will be used to
+	// create a credential in Kong, otherwise an ID
+	// is auto-generated.
+	Create(ctx context.Context, credType string, consumerUsernameOrID *string, credential interface{}) (json.RawMessage, error)
+	// Get fetches a credential of credType with credIdentifier from Kong.
+	Get(ctx context.Context, credType string, consumerUsernameOrID *string, credIdentifier *string) (json.RawMessage, error)
+	// Update updates credential in Kong
+	Update(ctx context.Context, credType string, consumerUsernameOrID *string, credential interface{}) (json.RawMessage, error)
+	// Delete deletes a credential in Kong
+	Delete(ctx context.Context, credType string, consumerUsernameOrID, credIdentifier *string) error
+}

--- a/kong/custom_entity_service.go
+++ b/kong/custom_entity_service.go
@@ -1,5 +1,7 @@
 package kong
 
+//go:generate ifacemaker -f custom_entity_service.go -s CustomEntityService -i CustomEntityServiceInterface -p kong -c "DO NOT EDIT: Auto generated" -o custom_entity_service_interface.go
+ 
 import (
 	"context"
 	"encoding/json"

--- a/kong/custom_entity_service_interface.go
+++ b/kong/custom_entity_service_interface.go
@@ -1,0 +1,27 @@
+// DO NOT EDIT: Auto generated
+
+package kong
+
+import (
+	"context"
+
+	"github.com/hbagdi/go-kong/kong/custom"
+)
+
+// CustomEntityServiceInterface ...
+type CustomEntityServiceInterface interface {
+	// Get fetches a custom entity. The primary key and all relations of the
+	// entity must be populated in entity.
+	Get(ctx context.Context, entity custom.Entity) (custom.Entity, error)
+	// Create creates a custom entity based on entity.
+	// All required fields must be present in entity.
+	Create(ctx context.Context, entity custom.Entity) (custom.Entity, error)
+	// Update updates a custom entity in Kong.
+	Update(ctx context.Context, entity custom.Entity) (custom.Entity, error)
+	// Delete deletes a custom entity in Kong.
+	Delete(ctx context.Context, entity custom.Entity) error
+	// List fetches all custom entities based on relations
+	List(ctx context.Context, opt *ListOpt, entity custom.Entity) ([]custom.Entity, *ListOpt, error)
+	// ListAll fetches all custom entities based on relations
+	ListAll(ctx context.Context, entity custom.Entity) ([]custom.Entity, error)
+}

--- a/kong/hmac_auth_service.go
+++ b/kong/hmac_auth_service.go
@@ -1,5 +1,7 @@
 package kong
 
+//go:generate ifacemaker -f hmac_auth_service.go -s HMACAuthService -i HMACAuthServiceInterface -p kong -c "DO NOT EDIT: Auto generated" -o hmac_auth_service_interface.go
+ 
 import (
 	"context"
 	"encoding/json"

--- a/kong/hmac_auth_service_interface.go
+++ b/kong/hmac_auth_service_interface.go
@@ -1,0 +1,33 @@
+// DO NOT EDIT: Auto generated
+
+package kong
+
+import (
+	"context"
+)
+
+// HMACAuthServiceInterface ...
+type HMACAuthServiceInterface interface {
+	// Create creates a hmac-auth credential in Kong
+	// If an ID is specified, it will be used to
+	// create a hmac-auth in Kong, otherwise an ID
+	// is auto-generated.
+	Create(ctx context.Context, consumerUsernameOrID *string, hmacAuth *HMACAuth) (*HMACAuth, error)
+	// Get fetches a hmac-auth credential from Kong.
+	Get(ctx context.Context, consumerUsernameOrID, usernameOrID *string) (*HMACAuth, error)
+	// Update updates a hmac-auth credential in Kong
+	Update(ctx context.Context, consumerUsernameOrID *string, hmacAuth *HMACAuth) (*HMACAuth, error)
+	// Delete deletes a hmac-auth credential in Kong
+	Delete(ctx context.Context, consumerUsernameOrID, usernameOrID *string) error
+	// List fetches a list of hmac-auth credentials in Kong.
+	// opt can be used to control pagination.
+	List(ctx context.Context, opt *ListOpt) ([]*HMACAuth, *ListOpt, error)
+	// ListAll fetches all hmac-auth credentials in Kong.
+	// This method can take a while if there
+	// a lot of hmac-auth credentials present.
+	ListAll(ctx context.Context) ([]*HMACAuth, error)
+	// ListForConsumer fetches a list of hmac-auth credentials
+	// in Kong associated with a specific consumer.
+	// opt can be used to control pagination.
+	ListForConsumer(ctx context.Context, consumerUsernameOrID *string, opt *ListOpt) ([]*HMACAuth, *ListOpt, error)
+}

--- a/kong/jwt_auth_service.go
+++ b/kong/jwt_auth_service.go
@@ -1,5 +1,7 @@
 package kong
 
+//go:generate ifacemaker -f jwt_auth_service.go -s JWTAuthService -i JWTAuthServiceInterface -p kong -c "DO NOT EDIT: Auto generated" -o jwt_auth_service_interface.go
+ 
 import (
 	"context"
 	"encoding/json"

--- a/kong/jwt_auth_service_interface.go
+++ b/kong/jwt_auth_service_interface.go
@@ -1,0 +1,33 @@
+// DO NOT EDIT: Auto generated
+
+package kong
+
+import (
+	"context"
+)
+
+// JWTAuthServiceInterface ...
+type JWTAuthServiceInterface interface {
+	// Create creates a JWT credential in Kong
+	// If an ID is specified, it will be used to
+	// create a JWT in Kong, otherwise an ID
+	// is auto-generated.
+	Create(ctx context.Context, consumerUsernameOrID *string, jwtAuth *JWTAuth) (*JWTAuth, error)
+	// Get fetches a JWT credential from Kong.
+	Get(ctx context.Context, consumerUsernameOrID, keyOrID *string) (*JWTAuth, error)
+	// Update updates a JWT credential in Kong
+	Update(ctx context.Context, consumerUsernameOrID *string, jwtAuth *JWTAuth) (*JWTAuth, error)
+	// Delete deletes a JWT credential in Kong
+	Delete(ctx context.Context, consumerUsernameOrID, keyOrID *string) error
+	// List fetches a list of JWT credentials in Kong.
+	// opt can be used to control pagination.
+	List(ctx context.Context, opt *ListOpt) ([]*JWTAuth, *ListOpt, error)
+	// ListAll fetches all JWT credentials in Kong.
+	// This method can take a while if there
+	// a lot of JWT credentials present.
+	ListAll(ctx context.Context) ([]*JWTAuth, error)
+	// ListForConsumer fetches a list of jwt credentials
+	// in Kong associated with a specific consumer.
+	// opt can be used to control pagination.
+	ListForConsumer(ctx context.Context, consumerUsernameOrID *string, opt *ListOpt) ([]*JWTAuth, *ListOpt, error)
+}

--- a/kong/key_auth_service.go
+++ b/kong/key_auth_service.go
@@ -1,5 +1,7 @@
 package kong
 
+//go:generate ifacemaker -f key_auth_service.go -s KeyAuthService -i KeyAuthServiceInterface -p kong -c "DO NOT EDIT: Auto generated" -o key_auth_service_interface.go
+ 
 import (
 	"context"
 	"encoding/json"

--- a/kong/key_auth_service_interface.go
+++ b/kong/key_auth_service_interface.go
@@ -1,0 +1,33 @@
+// DO NOT EDIT: Auto generated
+
+package kong
+
+import (
+	"context"
+)
+
+// KeyAuthServiceInterface ...
+type KeyAuthServiceInterface interface {
+	// Create creates a key-auth credential in Kong
+	// If an ID is specified, it will be used to
+	// create a key-auth in Kong, otherwise an ID
+	// is auto-generated.
+	Create(ctx context.Context, consumerUsernameOrID *string, keyAuth *KeyAuth) (*KeyAuth, error)
+	// Get fetches a key-auth credential from Kong.
+	Get(ctx context.Context, consumerUsernameOrID, keyOrID *string) (*KeyAuth, error)
+	// Update updates a key-auth credential in Kong
+	Update(ctx context.Context, consumerUsernameOrID *string, keyAuth *KeyAuth) (*KeyAuth, error)
+	// Delete deletes a key-auth credential in Kong
+	Delete(ctx context.Context, consumerUsernameOrID, keyOrID *string) error
+	// List fetches a list of key-auth credentials in Kong.
+	// opt can be used to control pagination.
+	List(ctx context.Context, opt *ListOpt) ([]*KeyAuth, *ListOpt, error)
+	// ListAll fetches all key-auth credentials in Kong.
+	// This method can take a while if there
+	// a lot of key-auth credentials present.
+	ListAll(ctx context.Context) ([]*KeyAuth, error)
+	// ListForConsumer fetches a list of key-auth credentials
+	// in Kong associated with a specific consumer.
+	// opt can be used to control pagination.
+	ListForConsumer(ctx context.Context, consumerUsernameOrID *string, opt *ListOpt) ([]*KeyAuth, *ListOpt, error)
+}

--- a/kong/kong.go
+++ b/kong/kong.go
@@ -32,22 +32,22 @@ type Client struct {
 	client         *http.Client
 	baseURL        string
 	common         service
-	Consumers      *ConsumerService
-	Services       *Svcservice
-	Routes         *RouteService
-	CACertificates *CACertificateService
-	Certificates   *CertificateService
-	Plugins        *PluginService
-	SNIs           *SNIService
-	Upstreams      *UpstreamService
-	Targets        *TargetService
+	Consumers      ConsumerServiceInterface
+	Services       SvcserviceInterface
+	Routes         RouteServiceInterface
+	CACertificates CACertificateServiceInterface
+	Certificates   CertificateServiceInterface
+	Plugins        PluginServiceInterface
+	SNIs           SNIServiceInterface
+	Upstreams      UpstreamServiceInterface
+	Targets        TargetServiceInterface
 
-	credentials *credentialService
-	KeyAuths    *KeyAuthService
-	BasicAuths  *BasicAuthService
-	HMACAuths   *HMACAuthService
-	JWTAuths    *JWTAuthService
-	ACLs        *ACLService
+	credentials credentialServiceInterface
+	KeyAuths    KeyAuthServiceInterface
+	BasicAuths  BasicAuthServiceInterface
+	HMACAuths   HMACAuthServiceInterface
+	JWTAuths    JWTAuthServiceInterface
+	ACLs        ACLServiceInterface
 
 	Oauth2Credentials *Oauth2Service
 

--- a/kong/oauth2_auth_service.go
+++ b/kong/oauth2_auth_service.go
@@ -1,5 +1,7 @@
 package kong
 
+//go:generate ifacemaker -f oauth2_auth_service.go -s Oauth2Service -i Oauth2ServiceInterface -p kong -c "DO NOT EDIT: Auto generated" -o oauth2_auth_service_interface.go
+ 
 import (
 	"context"
 	"encoding/json"

--- a/kong/oauth2_auth_service_interface.go
+++ b/kong/oauth2_auth_service_interface.go
@@ -1,0 +1,33 @@
+// DO NOT EDIT: Auto generated
+
+package kong
+
+import (
+	"context"
+)
+
+// Oauth2ServiceInterface ...
+type Oauth2ServiceInterface interface {
+	// Create creates an oauth2 credential in Kong
+	// If an ID is specified, it will be used to
+	// create a oauth2 credential in Kong, otherwise an ID
+	// is auto-generated.
+	Create(ctx context.Context, consumerUsernameOrID *string, oauth2Cred *Oauth2Credential) (*Oauth2Credential, error)
+	// Get fetches an oauth2 credential from Kong.
+	Get(ctx context.Context, consumerUsernameOrID, clientIDorID *string) (*Oauth2Credential, error)
+	// Update updates an oauth2 credential in Kong.
+	Update(ctx context.Context, consumerUsernameOrID *string, oauth2Cred *Oauth2Credential) (*Oauth2Credential, error)
+	// Delete deletes an oauth2 credential in Kong.
+	Delete(ctx context.Context, consumerUsernameOrID, clientIDorID *string) error
+	// List fetches a list of oauth2 credentials in Kong.
+	// opt can be used to control pagination.
+	List(ctx context.Context, opt *ListOpt) ([]*Oauth2Credential, *ListOpt, error)
+	// ListAll fetches all oauth2 credentials in Kong.
+	// This method can take a while if there
+	// a lot of oauth2 credentials present.
+	ListAll(ctx context.Context) ([]*Oauth2Credential, error)
+	// ListForConsumer fetches a list of oauth2 credentials
+	// in Kong associated with a specific consumer.
+	// opt can be used to control pagination.
+	ListForConsumer(ctx context.Context, consumerUsernameOrID *string, opt *ListOpt) ([]*Oauth2Credential, *ListOpt, error)
+}

--- a/kong/plugin_service.go
+++ b/kong/plugin_service.go
@@ -1,5 +1,7 @@
 package kong
 
+//go:generate ifacemaker -f plugin_service.go -s PluginService -i PluginServiceInterface -p kong -c "DO NOT EDIT: Auto generated" -o plugin_service_interface.go
+ 
 import (
 	"context"
 	"encoding/json"

--- a/kong/plugin_service_interface.go
+++ b/kong/plugin_service_interface.go
@@ -1,0 +1,35 @@
+// DO NOT EDIT: Auto generated
+
+package kong
+
+import (
+	"context"
+)
+
+// PluginServiceInterface ...
+type PluginServiceInterface interface {
+	// Create creates a Plugin in Kong.
+	// If an ID is specified, it will be used to
+	// create a plugin in Kong, otherwise an ID
+	// is auto-generated.
+	Create(ctx context.Context, plugin *Plugin) (*Plugin, error)
+	// Get fetches a Plugin in Kong.
+	Get(ctx context.Context, usernameOrID *string) (*Plugin, error)
+	// Update updates a Plugin in Kong
+	Update(ctx context.Context, plugin *Plugin) (*Plugin, error)
+	// Delete deletes a Plugin in Kong
+	Delete(ctx context.Context, usernameOrID *string) error
+	// List fetches a list of Plugins in Kong.
+	// opt can be used to control pagination.
+	List(ctx context.Context, opt *ListOpt) ([]*Plugin, *ListOpt, error)
+	// ListAll fetches all Plugins in Kong.
+	// This method can take a while if there
+	// a lot of Plugins present.
+	ListAll(ctx context.Context) ([]*Plugin, error)
+	// ListAllForConsumer fetches all Plugins in Kong enabled for a consumer.
+	ListAllForConsumer(ctx context.Context, consumerIDorName *string) ([]*Plugin, error)
+	// ListAllForService fetches all Plugins in Kong enabled for a service.
+	ListAllForService(ctx context.Context, serviceIDorName *string) ([]*Plugin, error)
+	// ListAllForRoute fetches all Plugins in Kong enabled for a service.
+	ListAllForRoute(ctx context.Context, routeID *string) ([]*Plugin, error)
+}

--- a/kong/route_service.go
+++ b/kong/route_service.go
@@ -1,5 +1,7 @@
 package kong
 
+//go:generate ifacemaker -f route_service.go -s RouteService -i RouteServiceInterface -p kong -c "DO NOT EDIT: Auto generated" -o route_service_interface.go
+ 
 import (
 	"context"
 	"encoding/json"

--- a/kong/route_service_interface.go
+++ b/kong/route_service_interface.go
@@ -1,0 +1,34 @@
+// DO NOT EDIT: Auto generated
+
+package kong
+
+import (
+	"context"
+)
+
+// RouteServiceInterface ...
+type RouteServiceInterface interface {
+	// Create creates a Route in Kong
+	// If an ID is specified, it will be used to
+	// create a route in Kong, otherwise an ID
+	// is auto-generated.
+	Create(ctx context.Context, route *Route) (*Route, error)
+	// CreateInService creates a route associated with serviceID
+	CreateInService(ctx context.Context, serviceID *string, route *Route) (*Route, error)
+	// Get fetches a Route in Kong.
+	Get(ctx context.Context, nameOrID *string) (*Route, error)
+	// Update updates a Route in Kong
+	Update(ctx context.Context, route *Route) (*Route, error)
+	// Delete deletes a Route in Kong
+	Delete(ctx context.Context, nameOrID *string) error
+	// List fetches a list of Routes in Kong.
+	// opt can be used to control pagination.
+	List(ctx context.Context, opt *ListOpt) ([]*Route, *ListOpt, error)
+	// ListAll fetches all Routes in Kong.
+	// This method can take a while if there
+	// a lot of Routes present.
+	ListAll(ctx context.Context) ([]*Route, error)
+	// ListForService fetches a list of Routes in Kong associated with a service.
+	// opt can be used to control pagination.
+	ListForService(ctx context.Context, serviceNameOrID *string, opt *ListOpt) ([]*Route, *ListOpt, error)
+}

--- a/kong/service_service.go
+++ b/kong/service_service.go
@@ -1,5 +1,7 @@
 package kong
 
+//go:generate ifacemaker -f service_service.go -s Svcservice -i SvcserviceInterface -p kong -c "DO NOT EDIT: Auto generated" -o service_service_interface.go
+ 
 import (
 	"context"
 	"encoding/json"

--- a/kong/service_service_interface.go
+++ b/kong/service_service_interface.go
@@ -1,0 +1,31 @@
+// DO NOT EDIT: Auto generated
+
+package kong
+
+import (
+	"context"
+)
+
+// SvcserviceInterface ...
+type SvcserviceInterface interface {
+	// Create creates an Service in Kong
+	// If an ID is specified, it will be used to
+	// create a service in Kong, otherwise an ID
+	// is auto-generated.
+	Create(ctx context.Context, service *Service) (*Service, error)
+	// Get fetches an Service in Kong.
+	Get(ctx context.Context, nameOrID *string) (*Service, error)
+	// GetForRoute fetches a Service associated with routeID in Kong.
+	GetForRoute(ctx context.Context, routeID *string) (*Service, error)
+	// Update updates an Service in Kong
+	Update(ctx context.Context, service *Service) (*Service, error)
+	// Delete deletes an Service in Kong
+	Delete(ctx context.Context, nameOrID *string) error
+	// List fetches a list of Services in Kong.
+	// opt can be used to control pagination.
+	List(ctx context.Context, opt *ListOpt) ([]*Service, *ListOpt, error)
+	// ListAll fetches all Services in Kong.
+	// This method can take a while if there
+	// a lot of Services present.
+	ListAll(ctx context.Context) ([]*Service, error)
+}

--- a/kong/sni_service.go
+++ b/kong/sni_service.go
@@ -1,5 +1,7 @@
 package kong
 
+//go:generate ifacemaker -f sni_service.go -s SNIService -i SNIServiceInterface -p kong -c "DO NOT EDIT: Auto generated" -o sni_service_interface.go
+ 
 import (
 	"context"
 	"encoding/json"

--- a/kong/sni_service_interface.go
+++ b/kong/sni_service_interface.go
@@ -1,0 +1,33 @@
+// DO NOT EDIT: Auto generated
+
+package kong
+
+import (
+	"context"
+)
+
+// SNIServiceInterface ...
+type SNIServiceInterface interface {
+	// Create creates a SNI in Kong.
+	// If an ID is specified, it will be used to
+	// create a sni in Kong, otherwise an ID
+	// is auto-generated.
+	Create(ctx context.Context, sni *SNI) (*SNI, error)
+	// Get fetches a SNI in Kong.
+	Get(ctx context.Context, usernameOrID *string) (*SNI, error)
+	// Update updates a SNI in Kong
+	Update(ctx context.Context, sni *SNI) (*SNI, error)
+	// Delete deletes a SNI in Kong
+	Delete(ctx context.Context, usernameOrID *string) error
+	// List fetches a list of SNIs in Kong.
+	// opt can be used to control pagination.
+	List(ctx context.Context, opt *ListOpt) ([]*SNI, *ListOpt, error)
+	// ListForCertificate fetches a list of SNIs
+	// in Kong associated with certificateID.
+	// opt can be used to control pagination.
+	ListForCertificate(ctx context.Context, certificateID *string, opt *ListOpt) ([]*SNI, *ListOpt, error)
+	// ListAll fetches all SNIs in Kong.
+	// This method can take a while if there
+	// a lot of SNIs present.
+	ListAll(ctx context.Context) ([]*SNI, error)
+}

--- a/kong/target_service.go
+++ b/kong/target_service.go
@@ -1,5 +1,7 @@
 package kong
 
+//go:generate ifacemaker -f target_service.go -s TargetService -i TargetServiceInterface -p kong -c "DO NOT EDIT: Auto generated" -o target_service_interface.go
+ 
 import (
 	"context"
 	"encoding/json"

--- a/kong/target_service_interface.go
+++ b/kong/target_service_interface.go
@@ -1,0 +1,29 @@
+// DO NOT EDIT: Auto generated
+
+package kong
+
+import (
+	"context"
+)
+
+// TargetServiceInterface ...
+type TargetServiceInterface interface {
+	// Create creates a Target in Kong under upstreamID.
+	// If an ID is specified, it will be used to
+	// create a target in Kong, otherwise an ID
+	// is auto-generated.
+	Create(ctx context.Context, upstreamNameOrID *string, target *Target) (*Target, error)
+	// Delete deletes a Target in Kong
+	Delete(ctx context.Context, upstreamNameOrID *string, targetOrID *string) error
+	// List fetches a list of Targets in Kong.
+	// opt can be used to control pagination.
+	List(ctx context.Context, upstreamNameOrID *string, opt *ListOpt) ([]*Target, *ListOpt, error)
+	// ListAll fetches all Targets in Kong for an upstream.
+	ListAll(ctx context.Context, upstreamNameOrID *string) ([]*Target, error)
+	// MarkHealthy marks target belonging to upstreamNameOrID as healthy in
+	// Kong's load balancer.
+	MarkHealthy(ctx context.Context, upstreamNameOrID *string, target *Target) error
+	// MarkUnhealthy marks target belonging to upstreamNameOrID as unhealthy in
+	// Kong's load balancer.
+	MarkUnhealthy(ctx context.Context, upstreamNameOrID *string, target *Target) error
+}

--- a/kong/upstream_service.go
+++ b/kong/upstream_service.go
@@ -1,5 +1,7 @@
 package kong
 
+//go:generate ifacemaker -f upstream_service.go -s UpstreamService -i UpstreamServiceInterface -p kong -c "DO NOT EDIT: Auto generated" -o upstream_service_interface.go
+ 
 import (
 	"context"
 	"encoding/json"

--- a/kong/upstream_service_interface.go
+++ b/kong/upstream_service_interface.go
@@ -1,0 +1,29 @@
+// DO NOT EDIT: Auto generated
+
+package kong
+
+import (
+	"context"
+)
+
+// UpstreamServiceInterface ...
+type UpstreamServiceInterface interface {
+	// Create creates a Upstream in Kong.
+	// If an ID is specified, it will be used to
+	// create a upstream in Kong, otherwise an ID
+	// is auto-generated.
+	Create(ctx context.Context, upstream *Upstream) (*Upstream, error)
+	// Get fetches a Upstream in Kong.
+	Get(ctx context.Context, upstreamNameOrID *string) (*Upstream, error)
+	// Update updates a Upstream in Kong
+	Update(ctx context.Context, upstream *Upstream) (*Upstream, error)
+	// Delete deletes a Upstream in Kong
+	Delete(ctx context.Context, upstreamNameOrID *string) error
+	// List fetches a list of Upstreams in Kong.
+	// opt can be used to control pagination.
+	List(ctx context.Context, opt *ListOpt) ([]*Upstream, *ListOpt, error)
+	// ListAll fetches all Upstreams in Kong.
+	// This method can take a while if there
+	// a lot of Upstreams present.
+	ListAll(ctx context.Context) ([]*Upstream, error)
+}


### PR DESCRIPTION
Addresses Issue #13 

Uses the go generate command to run [vburenin's ifacemaker](https://github.com/vburenin/ifacemaker) that generates files containing interfaces based on the structs.

Also includes a script that writes the go:generate comment to each of the service files.

The general idea is that users of the library can now create mocks of the various Services. This ensures testing boundaries within a given code base coincide with the use of the library. That is, tests in user's code test only their code and can provide success / failure scenarios by mocking the required service and focus on the "Class Under Test".