### PR TITLE
Adds support for setting type on passive healthchecks

### DIFF
--- a/kong/types.go
+++ b/kong/types.go
@@ -127,6 +127,7 @@ type ActiveHealthcheck struct {
 // +k8s:deepcopy-gen=true
 type PassiveHealthcheck struct {
 	Healthy   *Healthy   `json:"healthy,omitempty" yaml:"healthy,omitempty"`
+	Type      *string    `json:"type,omitempty" yaml:"type,omitempty"`
 	Unhealthy *Unhealthy `json:"unhealthy,omitempty" yaml:"unhealthy,omitempty"`
 }
 

--- a/kong/upstream_service_test.go
+++ b/kong/upstream_service_test.go
@@ -123,6 +123,34 @@ func TestUpstreamWithPassiveUnHealthyInterval(T *testing.T) {
 	assert.NotNil(err)
 	assert.Nil(createdUpstream)
 }
+func TestUpstreamWithPassiveHealthy(T *testing.T) {
+	assert := assert.New(T)
+
+	client, err := NewClient(nil, nil)
+	assert.Nil(err)
+	assert.NotNil(client)
+
+	upstream := &Upstream{
+		Name: String("upstream-foo"),
+		Healthchecks: &Healthcheck{
+			Passive: &PassiveHealthcheck{
+				Type: String("http"),
+				Healthy: &Healthy{
+					HTTPStatuses: []int{200, 201},
+					Successes:    Int(3),
+				},
+			},
+		},
+	}
+
+	createdUpstream, err := client.Upstreams.Create(defaultCtx, upstream)
+	assert.Nil(err)
+	assert.NotNil(createdUpstream)
+	assert.Equal("http", *createdUpstream.Healthchecks.Passive.Type)
+
+	err = client.Upstreams.Delete(defaultCtx, createdUpstream.ID)
+	assert.Nil(err)
+}
 
 func TestUpstreamWithAlgorithm(T *testing.T) {
 	runWhenKong(T, ">=1.3.0")


### PR DESCRIPTION
This is a small addition that I uncovered while working through a terraform-provider-kong port to go-kong. It looks like Type is supported by passive healthchecks and can be included here. 

Referencing: https://docs.konghq.com/enterprise/1.5.x/admin-api/#update-or-create-upstream