### PR TITLE
tests: use build flag instead of runWhen for enteprise only test files

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,7 @@ jobs:
   test:
     strategy:
       matrix:
-        kong_version: [ '1.0.3', '1.1.2', '1.2.0', '1.3.0', '1.4.0', '2.0.4', 'enterprise-1.3.0.2', 'enterprise-1.5.0.2']
+        kong_version: [ '1.0.3', '1.1.2', '1.2.0', '1.3.0', '1.4.0', '2.0.4']
     env:
       KONG_VERSION: ${{ matrix.kong_version }}
       KONG_ENTERPRISE_REPO_USERNAME: ${{ secrets.KONG_ENTERPRISE_REPO_USERNAME }}
@@ -52,3 +52,37 @@ jobs:
         run: bash .ci/setup_kong.sh
       - name: Run tests
         run: go test -v ./...
+  test-entrprise:
+    strategy:
+      matrix:
+        kong_version: ['enterprise-1.3.0.2', 'enterprise-1.5.0.2']
+    env:
+      KONG_VERSION: ${{ matrix.kong_version }}
+      KONG_ENTERPRISE_REPO_USERNAME: ${{ secrets.KONG_ENTERPRISE_REPO_USERNAME }}
+      KONG_ENTERPRISE_REPO_PASSSWORD: ${{ secrets.KONG_ENTERPRISE_REPO_PASSSWORD }}
+      KONG_LICENSE_DATA: ${{ secrets.KONG_LICENSE_DATA }}
+      KONG_ANONYMOUS_REPORTS: "off"
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:11.6-alpine
+        ports:
+          - 5432:5432
+        # needed because the postgres container does not provide a healthcheck
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+    steps:
+      - name: Setup go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.14'
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Setup Postgres
+        run: |
+          psql -c 'create database kong;' -U postgres -h 127.0.0.1 -p 5432
+          psql -c 'create user kong;' -U postgres -h 127.0.0.1 -p 5432
+          psql -c 'GRANT ALL PRIVILEGES ON DATABASE "kong" to kong;' -U postgres -h 127.0.0.1 -p 5432
+      - name: Setup Kong
+        run: bash .ci/setup_kong.sh
+      - name: Run tests
+        run: go test -tags=enterprise -v ./...

--- a/kong/kong_test.go
+++ b/kong/kong_test.go
@@ -147,3 +147,18 @@ func runWhenEnterprise(t *testing.T, semverRange string) {
 	runWhenKong(t, semverRange)
 
 }
+
+func TestRunWhenEnterprise(T *testing.T) {
+	runWhenEnterprise(T, ">=0.33.0")
+	assert := assert.New(T)
+
+	client, err := NewClient(nil, nil)
+	assert.Nil(err)
+	assert.NotNil(client)
+
+	root, err := client.Root(defaultCtx)
+	assert.Nil(err)
+	assert.NotNil(root)
+	v := root["version"].(string)
+	assert.Contains(v, "enterprise")
+}

--- a/kong/mtls_auth_service_test.go
+++ b/kong/mtls_auth_service_test.go
@@ -1,3 +1,5 @@
+// +build enterprise
+
 package kong
 
 import (
@@ -7,7 +9,6 @@ import (
 )
 
 func TestMTLSCreate(T *testing.T) {
-	runWhenEnterprise(T, ">=0.36.0")
 	assert := assert.New(T)
 
 	client, err := NewClient(nil, nil)
@@ -74,7 +75,6 @@ func TestMTLSCreate(T *testing.T) {
 }
 
 func TestMTLSCreateWithID(T *testing.T) {
-	runWhenEnterprise(T, ">=0.36.0")
 	assert := assert.New(T)
 
 	client, err := NewClient(nil, nil)
@@ -108,7 +108,6 @@ func TestMTLSCreateWithID(T *testing.T) {
 }
 
 func TestMTLSGet(T *testing.T) {
-	runWhenEnterprise(T, ">=0.36.0")
 	assert := assert.New(T)
 
 	client, err := NewClient(nil, nil)
@@ -151,7 +150,6 @@ func TestMTLSGet(T *testing.T) {
 }
 
 func TestMTLSUpdate(T *testing.T) {
-	runWhenEnterprise(T, ">=0.36.0")
 	assert := assert.New(T)
 
 	client, err := NewClient(nil, nil)
@@ -191,7 +189,6 @@ func TestMTLSUpdate(T *testing.T) {
 }
 
 func TestMTLSDelete(T *testing.T) {
-	runWhenEnterprise(T, ">=0.36.0")
 	assert := assert.New(T)
 
 	client, err := NewClient(nil, nil)
@@ -228,7 +225,6 @@ func TestMTLSDelete(T *testing.T) {
 }
 
 func TestMTLSListMethods(T *testing.T) {
-	runWhenEnterprise(T, ">=0.36.0")
 	assert := assert.New(T)
 
 	client, err := NewClient(nil, nil)

--- a/kong/workspace_service_test.go
+++ b/kong/workspace_service_test.go
@@ -1,3 +1,5 @@
+// +build enterprise
+
 package kong
 
 import (
@@ -8,7 +10,6 @@ import (
 )
 
 func TestWorkspaceService(T *testing.T) {
-	runWhenEnterprise(T, ">=0.33.0")
 	assert := assert.New(T)
 
 	client, err := NewClient(nil, nil)
@@ -60,7 +61,6 @@ func TestWorkspaceService(T *testing.T) {
 }
 
 func TestWorkspaceServiceList(T *testing.T) {
-	runWhenEnterprise(T, ">=0.33.0")
 	assert := assert.New(T)
 
 	client, err := NewClient(nil, nil)
@@ -99,7 +99,6 @@ func TestWorkspaceServiceList(T *testing.T) {
 }
 
 func TestWorkspaceServiceListAll(T *testing.T) {
-	runWhenEnterprise(T, ">=0.33.0")
 	assert := assert.New(T)
 
 	client, err := NewClient(nil, nil)


### PR DESCRIPTION
Build flags are more maintainable to segregate tests using Go's
toolchain.

`runWhen*` functions should still be used when:
- a file contain a mix of enterprise and open source tests in the same file
- a test is added which should run only for a specific version(s) of enterprise