### PR TITLE
Provide insight into Kong EE package download failures

### DIFF
--- a/.ci/setup_kong.sh
+++ b/.ci/setup_kong.sh
@@ -20,11 +20,15 @@ function setup_kong(){
 }
 
 function setup_kong_enterprise(){
-  KONG_VERSION=${KONG_VERSION#"enterprise-"}
+  KONG_VERSION=${enterprise-1.5.0.2#"enterprise-"}
   URL="https://kong.bintray.com/kong-enterprise-edition-deb/dists/kong-enterprise-edition-${KONG_VERSION}.xenial.all.deb"
-  /usr/bin/curl -sL \
+  RESPONSE_CODE=$(/usr/bin/curl -sL \
+    -w "%{http_code}" \
     -u $KONG_ENTERPRISE_REPO_USERNAME:$KONG_ENTERPRISE_REPO_PASSSWORD \
-    $URL -o kong.deb
+    $URL -o kong.deb)
+  if [[ $RESPONSE_CODE != "200" ]]; then
+    echo "error retrieving kong enterprise package. response code ${RESPONSE_CODE}"
+  fi
 }
 
 if [[ $KONG_VERSION == *"enterprise"* ]]; then

--- a/.ci/setup_kong.sh
+++ b/.ci/setup_kong.sh
@@ -20,7 +20,7 @@ function setup_kong(){
 }
 
 function setup_kong_enterprise(){
-  KONG_VERSION=${enterprise-1.5.0.2#"enterprise-"}
+  KONG_VERSION="${KONG_VERSION#enterprise-}"
   URL="https://kong.bintray.com/kong-enterprise-edition-deb/dists/kong-enterprise-edition-${KONG_VERSION}.xenial.all.deb"
   RESPONSE_CODE=$(/usr/bin/curl -sL \
     -w "%{http_code}" \

--- a/.ci/setup_kong.sh
+++ b/.ci/setup_kong.sh
@@ -27,7 +27,8 @@ function setup_kong_enterprise(){
     -u $KONG_ENTERPRISE_REPO_USERNAME:$KONG_ENTERPRISE_REPO_PASSSWORD \
     $URL -o kong.deb)
   if [[ $RESPONSE_CODE != "200" ]]; then
-    echo "error retrieving kong enterprise package. response code ${RESPONSE_CODE}"
+    echo "error retrieving kong enterprise package from ${URL}. response code ${RESPONSE_CODE}"
+    exit 1 
   fi
 }
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -52,7 +52,7 @@ jobs:
         run: bash .ci/setup_kong.sh
       - name: Run tests
         run: go test -v ./...
-  test-entrprise:
+  test-enterprise:
     strategy:
       matrix:
         kong_version: ['enterprise-1.3.0.2', 'enterprise-1.5.0.2']


### PR DESCRIPTION
This patch tries to shed some light on why the EE test suite is failing. I found that the Kong Version substitution needed a slight fix, but after that, we're still getting 401s which suggests the creds being passed in aren't valid. This patch also fixes a minor typo in the test job name.